### PR TITLE
add patch for linux-gpib-kernel for docker build

### DIFF
--- a/recipes-kernel/linux-gpib-kernel/files/make-install-depmod.patch
+++ b/recipes-kernel/linux-gpib-kernel/files/make-install-depmod.patch
@@ -1,0 +1,19 @@
+Index: linux-gpib-kernel/Makefile
+===================================================================
+--- linux-gpib-kernel/Makefile    (revision 1914)
++++ linux-gpib-kernel/Makefile    (working copy)
+@@ -5,6 +5,8 @@
+ VERBOSE ?= 0
+ ENABLE_PCMCIA ?= 0
+ GPIB_DEBUG ?= 0
++BASE_PATH ?= /
++KERNEL_VERSION ?= `uname -r`
+
+ all:
+ 		$(MAKE) -C $(LINUX_SRCDIR) V=$(VERBOSE) modules \
+@@ -28,5 +28,5 @@
+ 		M="$(GPIB_SRCDIR)/drivers/gpib" \
+ 		GPIB_TOP_DIR=$(GPIB_SRCDIR) \
+ 		INSTALL_MOD_DIR=gpib
+-	/sbin/depmod -A
++	depmod -A -b $(BASE_PATH) $(KERNEL_VERSION)

--- a/recipes-kernel/linux-gpib-kernel/linux-gpib-kernel_svn.bb
+++ b/recipes-kernel/linux-gpib-kernel/linux-gpib-kernel_svn.bb
@@ -7,13 +7,15 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 inherit module
 
-#SRCREV = "${AUTOREV}"
 SRCREV = "1914"
 PV = "svnr${SRCREV}"
 PR = "r0"
 
-SRC_URI = "svn://svn.code.sf.net/p/linux-gpib/code/;module=trunk/linux-gpib-kernel;protocol=https \
-"
+# The `make-install-depmod.patch` is really just for docker builds, otherwise
+# depmod will pull the host(the container) kernel version instead of yocto build.
+# Even so it doesn't look like we even need the output of depmod.
+SRC_URI = "svn://svn.code.sf.net/p/linux-gpib/code/;module=trunk/linux-gpib-kernel;protocol=https;rev=${SRCREV} \
+file://make-install-depmod.patch"
 
 S = "${WORKDIR}/trunk/linux-gpib-kernel"
 
@@ -22,7 +24,7 @@ S = "${WORKDIR}/trunk/linux-gpib-kernel"
 
 RPROVIDES_${PN} += "linux-gpib"
 
-EXTRA_OEMAKE += "LINUX_SRCDIR=${STAGING_KERNEL_DIR}"
+EXTRA_OEMAKE += "LINUX_SRCDIR=${STAGING_KERNEL_DIR} BASE_PATH=${D} KERNEL_VERSION=${KERNEL_VERSION}"
 
 MODULES_INSTALL_TARGET = "install"
 MODULES_MODULE_SYMVERS_LOCATION = "drivers/gpib/"


### PR DESCRIPTION
The changes fixes the following

```
/sbin/depmod -A
depmod: ERROR: could not open directory /lib/modules/5.19.0-43-generic: No such file or directory
depmod: ERROR: could not open directory /lib/modules/5.19.0-43-generic: No such file or directory
depmod: FATAL: could not search modules: No such file or directory
Makefile:28: recipe for target 'install' failed
```

`depmod` appears to be running base on the host directory and not relative to the yocto build. So it's interesting that this was working before outside of docker.